### PR TITLE
Fix affiliation listing in LaTeX

### DIFF
--- a/fixtures/paper/paper.md
+++ b/fixtures/paper/paper.md
@@ -7,10 +7,15 @@ tags:
 authors:
  - name: Arfon M Smith
    orcid: 0000-0002-3957-2474
-   affiliation: GitHub Inc.
+   affiliation: 1
  - name: Mickey Mouse
    orcid: 0000-0000-0000-1234
-   affiliation: Disney Inc.
+   affiliation: 2
+affiliations:
+ - name: GitHub Inc.
+   index: 1
+ - name: Disney Inc.
+   index: 2
 date: 14 February 2016
 bibliography: paper.bib
 ---

--- a/resources/latex.template
+++ b/resources/latex.template
@@ -200,10 +200,17 @@ $endif$
 
 $if(authors)$
   $for(authors)$
-  \author{$authors.name$}
   $if(authors.affiliation)$
-  \affil{$authors.affiliation$}
+    \author[$authors.affiliation$]{$authors.name$}
+  $else$
+    \author{$authors.name$}
   $endif$
+  $endfor$
+$endif$
+
+$if(affiliations)$
+  $for(affiliations)$
+    \affil[$affiliations.index$]{$affiliations.name$}
   $endfor$
 $endif$
 \date{$date$}


### PR DESCRIPTION
This allows users to specify the indexing of their listed affiliations and avoids redundancies (see https://github.com/openjournals/joss-reviews/issues/34#issuecomment-237753538).