### PR TITLE
added DOI and ISSN meta tags to article HTML template

### DIFF
--- a/resources/html.template
+++ b/resources/html.template
@@ -3,7 +3,9 @@ body = <<-EOF
 $google_authors$
 <meta name="citation_publication_date" content="$timestamp$">
 <meta name="citation_journal_title" content="The Journal of Open Source Software">
+<meta name="citation_issn" content="2475-9066">
 <meta name="citation_pdf_url" content="$paper_url$">
+<meta name="citation_doi" content="$formatted_doi$">
 <div class="accepted-paper">
   <h1>$title$</h1>
   <div class="columns links">


### PR DESCRIPTION
This PR adds `citation_doi` and `citation_issn` tags to the HTML template for articles. This should enable proper tracking of social media mentions by altmetrics (see https://github.com/openjournals/joss/issues/110), and further addresses another aspect of https://github.com/openjournals/joss/issues/222 .