### PR TITLE
Add Pandoc 2 option to autolink URLs

### DIFF
--- a/lib/whedon/processor.rb
+++ b/lib/whedon/processor.rb
@@ -119,6 +119,7 @@ module Whedon
       -o #{paper.filename_doi}.pdf -V geometry:margin=1in \
       --pdf-engine=xelatex \
       --filter pandoc-citeproc #{File.basename(paper.paper_path)} \
+      --from markdown+autolink_bare_uris \
       --template #{latex_template_path}`
 
       if File.exists?("#{paper.directory}/#{paper.filename_doi}.pdf")


### PR DESCRIPTION
This adds autolinking of URLs, e.g. in footnotes in submission 502. It seems that they are otherwise not picked up consistently. 

We could add "+smart" as well but it seems that this is not necessary. I couldn't find an example where the LaTeX output didn't have proper quotes.