### PR TITLE
Display https doi link in PDF footer and HTML page

### DIFF
--- a/resources/html.template
+++ b/resources/html.template
@@ -42,7 +42,7 @@ $google_authors$
     </div>
     <div class="two-thirds column" style="padding-top: 20px;">
       <span class="paper">Citation:<br />
-      <small>$citation_author$, ($year$). $paper_title$. <em>Journal of Open Source Software</em>, $volume$($issue$), $page$, doi:$formatted_doi$</small>
+      <small>$citation_author$, ($year$). $paper_title$. <em>Journal of Open Source Software</em>, $volume$($issue$), $page$. https://doi.org/$formatted_doi$</small>
     </div>
   </div>
   <div class="paper-body">

--- a/resources/latex.template
+++ b/resources/latex.template
@@ -61,7 +61,7 @@
 \fancyhead[R]{}
 \renewcommand{\footrulewidth}{0.25pt}
 
-\fancyfoot[L]{\footnotesize{\sffamily $citation_author$, ($year$). $paper_title$. \textit{Journal of Open Source Software}, $volume$($issue$), $page$, \href{https://doi.org/$formatted_doi$}{doi:$formatted_doi$}}}
+\fancyfoot[L]{\footnotesize{\sffamily $citation_author$, ($year$). $paper_title$. \textit{Journal of Open Source Software}, $volume$($issue$), $page$. \href{https://doi.org/$formatted_doi$}{https://doi.org/$formatted_doi$}}}
 
 
 \fancyfoot[R]{\sffamily \thepage}


### PR DESCRIPTION
Following the Crossref guidelines outlined at
https://www.crossref.org/display-guidelines/

Main argument:
> To make it as easy as possible for users without technical
> knowledge to cut and paste or click to share Crossref DOIs
> (e.g. using right click to copy a URL).

Before:

Senyondo et al., (2017). Retriever: Data Retrieval Tool. Journal of Open Source Software, 2(19), 451, doi:10.21105/joss.00451

After:

Senyondo et al., (2017). Retriever: Data Retrieval Tool. Journal of Open Source Software, 2(19), 451. https://doi.org/10.21105/joss.00451
