### PR TITLE
ORCID validations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,7 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     netrc (0.11.0)
-    nokogiri (1.8.1)
+    nokogiri (1.8.3)
       mini_portile2 (~> 2.3.0)
     octokit (4.9.0)
       sawyer (~> 0.8.0, >= 0.5.3)

--- a/fixtures/paper/paper.md
+++ b/fixtures/paper/paper.md
@@ -9,7 +9,7 @@ authors:
    orcid: 0000-0002-3957-2474
    affiliation: "1,2"
  - name: Mickey Mouse
-   orcid: 0000-0000-0000-1234
+   orcid: 0000-0002-3957-2474
    affiliation: 2
 affiliations:
  - name: GitHub Inc.

--- a/lib/whedon/orcid_validator.rb
+++ b/lib/whedon/orcid_validator.rb
@@ -1,0 +1,83 @@
+class String
+  def numeric?
+    Float(self) != nil rescue false
+  end
+end
+
+module Whedon
+  class OrcidValidator
+    attr_reader :orcid
+
+    def initialize(orcid)
+      @orcid = orcid.strip
+    end
+
+    # Returns true or false
+    def validate
+      return false unless check_structure
+      return false unless check_length
+      return false unless check_chars
+
+      if checksum_char == "X" || checksum_char == "x"
+        return checksum == 10
+      else
+        return checksum == checksum_char.to_i
+      end
+    end
+
+    def packed_orcid
+      orcid.gsub('-', '')
+    end
+
+    # Returns the last character of the string
+    def checksum_char
+      packed_orcid[-1]
+    end
+
+    def first_11
+      packed_orcid.chop
+    end
+
+    def check_structure
+      groups = orcid.split('-')
+      if groups.size == 4
+        return true
+      else
+        warn("ORCID looks malformed") and return false
+      end
+    end
+
+    def check_length
+      if packed_orcid.length == 16
+        return true
+      else
+        warn("ORCID looks to be the wrong length") and return false
+      end
+    end
+
+    def check_chars
+      valid = true
+      first_11.each_char do |c|
+        if !c.numeric?
+          warn("Invalid ORDIC digit (#{c})")
+          valid = false
+        end
+      end
+
+      return valid
+    end
+
+    # https://support.orcid.org/knowledgebase/articles/116780-structure-of-the-orcid-identifier
+    def checksum
+      total = 0
+      first_11.each_char do |c|
+        total = (total + c.to_i) * 2
+      end
+
+      remainder = total % 11
+      result = (12 - remainder) % 11
+
+      return result
+    end
+  end
+end

--- a/spec/orcid_validator_spec.rb
+++ b/spec/orcid_validator_spec.rb
@@ -1,0 +1,33 @@
+require_relative 'spec_helper'
+
+describe Whedon::OrcidValidator do
+
+  context "checksum validations" do
+    it "should return true for a valid ORCID" do
+      subject = Whedon::OrcidValidator.new("0000-0002-3957-2474")
+      expect(subject.validate).to be_truthy
+    end
+
+    it "should return false for an invalid ORCID" do
+      subject = Whedon::OrcidValidator.new("0000-0002-3957-247X")
+      expect(subject.validate).to be_falsey
+    end
+  end
+
+  context "structure validations" do
+    it "should fail for a valid ORCID that's badly structured" do
+      subject = Whedon::OrcidValidator.new("0000000239572474")
+      expect(subject.validate).to be_falsey
+    end
+
+    it "should fail for an ORCID with the wrong length" do
+      subject = Whedon::OrcidValidator.new("0000-0002-3957-247")
+      expect(subject.validate).to be_falsey
+    end
+
+    it "should fail for an ORCID invalid characters" do
+      subject = Whedon::OrcidValidator.new("0000-000X-3957-2474")
+      expect(subject.validate).to be_falsey
+    end
+  end
+end


### PR DESCRIPTION
Sometimes people submit papers with invalid ORCIDs. Crossref deposit validation is the first we usually here about this. 

This change adds ORCID validation (both structure and a checksum) for author ORCIDs which means @whedon should complain about this when compiling the paper.