### PR TITLE
xeCJK package provides support for cjk characters in latex.template

### DIFF
--- a/resources/latex.template
+++ b/resources/latex.template
@@ -16,6 +16,7 @@
 \usepackage{ifxetex,ifluatex}
 \usepackage{seqsplit}
 \usepackage{fixltx2e} % provides \textsubscript
+\usepackage{xeCJK} % support chinese japanese korean characters
 \usepackage[
   backend=biber,
 %  style=alphabetic,


### PR DESCRIPTION
I recently submitted a paper to JOSS: https://github.com/openjournals/joss-reviews/issues/848#issuecomment-408005727

The software in question has internationalization features, and one of the code examples produces Chinese characters. Unfortunately, those don't get properly rendered when `whedon` compiles the document.

It's pretty hard to test whedon on my local machine, but I believe that this PR should offer support for CJK characters. In any case, this seems like a pretty low risk change, since it's a single line of code.