### PR TITLE
Made code (inside \texttt) splittable

### DIFF
--- a/resources/latex.template
+++ b/resources/latex.template
@@ -15,6 +15,12 @@
 \usepackage{amssymb,amsmath}
 \usepackage{ifxetex,ifluatex}
 \usepackage{seqsplit}
+\let\textttOrig=\texttt
+\def\texttt#1{\expandafter\textttOrig{\seqsplit{#1}}}
+\renewcommand{\seqinsert}{\ifmmode
+  \allowbreak
+  \else\penalty6000\hspace{0pt plus 0.02em}\fi}
+
 \usepackage{fixltx2e} % provides \textsubscript
 \usepackage[
   backend=biber,

--- a/resources/latex.template
+++ b/resources/latex.template
@@ -15,11 +15,7 @@
 \usepackage{amssymb,amsmath}
 \usepackage{ifxetex,ifluatex}
 \usepackage{seqsplit}
-\let\textttOrig=\texttt
-\def\texttt#1{\expandafter\textttOrig{\seqsplit{#1}}}
-\renewcommand{\seqinsert}{\ifmmode
-  \allowbreak
-  \else\penalty6000\hspace{0pt plus 0.02em}\fi}
+
 
 \usepackage{fixltx2e} % provides \textsubscript
 \usepackage[
@@ -28,6 +24,26 @@
 %  citestyle=numeric
 ]{biblatex}
 \bibliography{$bibliography$}
+
+% --- Splitting \texttt --------------------------------------------------
+
+\let\textttOrig=\texttt
+\def\texttt#1{\expandafter\textttOrig{\seqsplit{#1}}}
+\renewcommand{\seqinsert}{\ifmmode
+  \allowbreak
+  \else\penalty6000\hspace{0pt plus 0.02em}\fi}
+
+
+% --- Transform URLs in the form \href{https://doi.org/DOI}{DOI}
+% --- into splittable \href{https://doi.org/DOI}{\path{DOI}}
+
+\let\hrefOrig=\href
+\def\href#1#2{\def\tempa{#1}\def\tempb{https://doi.org/#2}%
+	\ifx\tempa\tempb\relax
+	   \hrefOrig{#1}{\path{#2}}%
+	\else
+	    \hrefOrig{#1}{#2}%
+	\fi}
 
 
 % --- Page layout -------------------------------------------------------------

--- a/resources/latex.template
+++ b/resources/latex.template
@@ -15,7 +15,7 @@
 \usepackage{amssymb,amsmath}
 \usepackage{ifxetex,ifluatex}
 \usepackage{seqsplit}
-
+\usepackage{xstring}
 
 \usepackage{fixltx2e} % provides \textsubscript
 \usepackage[
@@ -34,16 +34,31 @@
   \else\penalty6000\hspace{0pt plus 0.02em}\fi}
 
 
-% --- Transform URLs in the form \href{https://doi.org/DOI}{DOI}
-% --- into splittable \href{https://doi.org/DOI}{\path{DOI}}
+% --- Pandoc does not distinguish between links like [foo](bar) and
+% --- [foo](foo) -- a simplistic Markdown model.  However, this is
+% --- wrong:  in links like [foo](foo) the text is the url, and must
+% --- be split correspondingly.
+% --- Here we detect links \href{foo}{foo}, and also links starting
+% --- with https://doi.org, and use path-like splitting (but not
+% --- escaping!) with these links.
+% --- Another vile thing pandoc does is the different escaping of
+% --- foo and bar.  This may confound our detection.
+% --- This problem we do not try to solve at present, with the exception
+% --- of doi-like urls, which we detect correctly.
 
-\let\hrefOrig=\href
-\def\href#1#2{\def\tempa{#1}\def\tempb{https://doi.org/#2}%
-	\ifx\tempa\tempb\relax
-	   \hrefOrig{#1}{\path{#2}}%
-	\else
-	    \hrefOrig{#1}{#2}%
-	\fi}
+
+\makeatletter
+\let\href@Orig=\href
+\def\href@Urllike#1#2{\href@Orig{#1}{\begingroup
+    \def\Url@String{#2}\Url@FormatString
+    \endgroup}}
+\def\href@Notdoi#1#2{\def\tempa{#1}\def\tempb{#2}%
+  \ifx\tempa\tempb\relax\href@Urllike{#1}{#2}\else
+  \href@Orig{#1}{#2}\fi}
+\def\href#1#2{%
+  \IfBeginWith{#1}{https://doi.org}%
+  {\href@Urllike{#1}{#2}}{\href@Notdoi{#1}{#2}}}
+\makeatother
 
 
 % --- Page layout -------------------------------------------------------------


### PR DESCRIPTION
Make \texttt{.....} splittable, avoiding overfull lines