### PR TITLE
Adding authors information to joss_deposit payload

### DIFF
--- a/lib/whedon/processor.rb
+++ b/lib/whedon/processor.rb
@@ -3,6 +3,7 @@ require 'restclient'
 require 'securerandom'
 require 'yaml'
 require 'uri'
+require 'json'
 
 module Whedon
   class Processor
@@ -182,7 +183,7 @@ module Whedon
                   :archive_doi => archive_doi,
                   :citation_string => citation_string,
                   :title => paper.plain_title,
-                  :authors => URI.encode_www_form(authors_map),
+                  :authors => URI.encode_www_form_component(authors_map.to_json),
                   :secret => ENV['WHEDON_SECRET']
                 })
 

--- a/lib/whedon/processor.rb
+++ b/lib/whedon/processor.rb
@@ -155,8 +155,8 @@ module Whedon
 
     def authors_map
       authors = {}
-      paper.authors.each do |a|
-        authors[a.orcid] = a.name
+      paper.authors.each_with_index do |a, index|
+        authors[index] = {'name' => a.name, 'orcid' => a.orcid}
       end
       return authors
     end

--- a/lib/whedon/processor.rb
+++ b/lib/whedon/processor.rb
@@ -2,6 +2,7 @@ require_relative 'github'
 require 'restclient'
 require 'securerandom'
 require 'yaml'
+require 'uri'
 
 module Whedon
   class Processor
@@ -152,6 +153,14 @@ module Whedon
       return "#{paper.citation_author}, (#{paper_year}). #{paper.plain_title}. #{ENV['JOURNAL_NAME']}, #{paper_volume}(#{paper_issue}), #{paper.review_issue_id}, https://doi.org/#{paper.formatted_doi}"
     end
 
+    def authors_map
+      authors = {}
+      paper.authors.each do |a|
+        authors[a.orcid] = a.name
+      end
+      return authors
+    end
+
     def deposit
       crossref_deposit
       joss_deposit
@@ -173,6 +182,7 @@ module Whedon
                   :archive_doi => archive_doi,
                   :citation_string => citation_string,
                   :title => paper.plain_title,
+                  :authors => URI.encode_www_form(authors_map),
                   :secret => ENV['WHEDON_SECRET']
                 })
 


### PR DESCRIPTION
Adds hash of authors ORCID to their name to the payload sent to JOSS when the deposit is done. Required to complete openjournals/joss#458