### PR TITLE
Use title instead of plain_title in footnotes

### DIFF
--- a/lib/whedon/processor.rb
+++ b/lib/whedon/processor.rb
@@ -99,6 +99,8 @@ module Whedon
 
       # TODO: Sanitize all the things!
       paper_title = paper.title.gsub!('_', '\_')
+      plain_title = paper.plain_title.gsub('_', '\_')
+      plain_title = paper.plain_title.gsub('#', '\#')
       paper_year ||= Time.now.strftime('%Y')
       paper_issue ||= @current_issue
       paper_volume ||= @current_volume
@@ -129,7 +131,7 @@ module Whedon
       -V formatted_doi="#{paper.formatted_doi}" \
       -V citation_author="#{paper.citation_author}" \
       -V paper_title='#{paper.title}' \
-      -V footnote_paper_title='#{paper.plain_title}' \
+      -V footnote_paper_title='#{plain_title}' \
       -o #{paper.filename_doi}.pdf -V geometry:margin=1in \
       --pdf-engine=xelatex \
       --filter pandoc-citeproc #{File.basename(paper.paper_path)} \

--- a/lib/whedon/processor.rb
+++ b/lib/whedon/processor.rb
@@ -99,8 +99,7 @@ module Whedon
 
       # TODO: Sanitize all the things!
       paper_title = paper.title.gsub!('_', '\_')
-      plain_title = paper.plain_title.gsub('_', '\_')
-      plain_title = paper.plain_title.gsub('#', '\#')
+      plain_title = paper.plain_title.gsub('_', '\_').gsub('#', '\#')
       paper_year ||= Time.now.strftime('%Y')
       paper_issue ||= @current_issue
       paper_volume ||= @current_volume

--- a/resources/latex.template
+++ b/resources/latex.template
@@ -98,7 +98,7 @@
 \fancyhead[R]{}
 \renewcommand{\footrulewidth}{0.25pt}
 
-\fancyfoot[L]{\parbox[t]{0.98\headwidth}{\footnotesize{\sffamily $citation_author$, ($year$). $footnote_paper_title$. \textit{$journal_name$}, $volume$($issue$), $page$. \url{https://doi.org/$formatted_doi$}}}}
+\fancyfoot[L]{\parbox[t]{0.98\headwidth}{\footnotesize{\sffamily $citation_author$, ($year$). $title$. \textit{$journal_name$}, $volume$($issue$), $page$. \url{https://doi.org/$formatted_doi$}}}}
 
 
 \fancyfoot[R]{\sffamily \thepage}

--- a/resources/latex.template
+++ b/resources/latex.template
@@ -98,7 +98,7 @@
 \fancyhead[R]{}
 \renewcommand{\footrulewidth}{0.25pt}
 
-\fancyfoot[L]{\parbox[t]{0.98\headwidth}{\footnotesize{\sffamily $citation_author$, ($year$). $title$. \textit{$journal_name$}, $volume$($issue$), $page$. \url{https://doi.org/$formatted_doi$}}}}
+\fancyfoot[L]{\parbox[t]{0.98\headwidth}{\footnotesize{\sffamily $citation_author$, ($year$). $footnote_paper_title$. \textit{$journal_name$}, $volume$($issue$), $page$. \url{https://doi.org/$formatted_doi$}}}}
 
 
 \fancyfoot[R]{\sffamily \thepage}


### PR DESCRIPTION
It looks like plain_title from Markdown is not sanitized unlike title.  I am not sure what other differences are there between these too, so please test this change before committing (it seems to work for me, but let us see)