### PR TITLE
Use HTTPS for paper license URL

### DIFF
--- a/resources/latex.template
+++ b/resources/latex.template
@@ -407,7 +407,7 @@ $endif$
 
   \vspace{2mm}
   {\bfseries License}\\
-  Authors of papers retain copyright and release the work under a Creative Commons Attribution 4.0 International License (\href{http://creativecommons.org/licenses/by/4.0/}{\color{linky}{CC-BY}}).
+  Authors of papers retain copyright and release the work under a Creative Commons Attribution 4.0 International License (\href{https://creativecommons.org/licenses/by/4.0/}{\color{linky}{CC-BY}}).
 }
 
 $for(include-before)$


### PR DESCRIPTION
This pull request switches the Creative Commons license URL to HTTPS.