### PR TITLE
Author Initials 

### DIFF
--- a/lib/whedon.rb
+++ b/lib/whedon.rb
@@ -254,11 +254,12 @@ module Whedon
     # 'Smith et al' for multiple authors or 'Smith' for a single author
     def citation_author
       surname = authors.first.last_name
+      initials = authors.first.initials
 
       if authors.size > 1
         return "#{surname} et al."
       else
-        return "#{surname}"
+        return "#{surname}, #{initials}"
       end
     end
 

--- a/lib/whedon/author.rb
+++ b/lib/whedon/author.rb
@@ -43,6 +43,10 @@ module Whedon
       @parsed_name.first
     end
 
+    def initials
+      [@parsed_name.first, @parsed_name.middle].compact.map {|v| v[0]}.zip(['.', '.', '.']).map(&:join) * ' '
+    end
+
     # Takes the author affiliation index and a hash of all affiliations and
     # associates them. Then builds (and assigns) the author affiliation string.
     def build_affiliation_string(index, affiliations_yaml)

--- a/spec/author_spec.rb
+++ b/spec/author_spec.rb
@@ -1,0 +1,17 @@
+require_relative 'spec_helper'
+
+describe Whedon::Author do
+
+  context "#initials" do
+    it "should return first name and middle name initials" do
+      subject = Whedon::Author.new("Sarah Michelle Gellar", "", nil, nil)
+      expect(subject.initials).to eq("S. M.")
+    end
+
+    it "should return first name initial if no middle name present" do
+      subject = Whedon::Author.new("Buffy Summers", "", nil, nil)
+      expect(subject.initials).to eq("B.")
+    end
+  end
+
+end

--- a/spec/whedon_spec.rb
+++ b/spec/whedon_spec.rb
@@ -66,7 +66,7 @@ describe Whedon do
 
   it "should know how to format citation strings for single-author papers" do
     expect(paper_with_one_author.authors.size).to eql(1)
-    expect(paper_with_one_author.citation_author).to eql("Smith")
+    expect(paper_with_one_author.citation_author).to eql("Smith, A. M.")
   end
 
   it "should know how to format citation strings for multi-author papers" do


### PR DESCRIPTION
This PR changes the citation string for single-author papers to include initials.

Fixes #50