### PR TITLE
Try to provide ISBN value in bibliography entries if DOI is missing

### DIFF
--- a/resources/apa.csl
+++ b/resources/apa.csl
@@ -130,6 +130,9 @@
           <if variable="DOI">
             <text variable="DOI" prefix="doi:"/>
           </if>
+          <else-if variable="ISBN">
+            <text variable="ISBN" prefix="ISBN:&#160;"/>
+          </else-if>
           <else>
             <choose>
               <if type="webpage">

--- a/resources/jose/apa.csl
+++ b/resources/jose/apa.csl
@@ -130,6 +130,9 @@
           <if variable="DOI">
             <text variable="DOI" prefix="doi:"/>
           </if>
+          <else-if variable="ISBN">
+            <text variable="ISBN" prefix="ISBN:&#160;"/>
+          </else-if>
           <else>
             <choose>
               <if type="webpage">

--- a/resources/joss/apa.csl
+++ b/resources/joss/apa.csl
@@ -130,6 +130,9 @@
           <if variable="DOI">
             <text variable="DOI" prefix="doi:"/>
           </if>
+          <else-if variable="ISBN">
+            <text variable="ISBN" prefix="ISBN:&#160;"/>
+          </else-if>
           <else>
             <choose>
               <if type="webpage">


### PR DESCRIPTION
This is untested.

Closes: openjournals/joss#392