### PR TITLE
Add a Dockerfile to allow easy creation of draft PDFs

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,63 @@
+name: Build Images
+
+on:
+  # Build and publish when pushed to master
+  push:
+    branches:
+      - master
+  # Build, but don't push on pull requests
+  pull_request:
+
+env:
+  IMAGE_NAME: openjournals/paperdraft
+
+jobs:
+  # Build images and store them as tar archive
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build image
+        run: |
+            docker build \
+              --tag $IMAGE_NAME \
+              -f paperdraft.Dockerfile \
+              .
+
+      - name: Save images to archive
+        run: docker save $IMAGE_NAME > image.tar
+
+      - name: Upload archive
+        uses: actions/upload-artifact@v1
+        with:
+          name: paperdraft
+          path: image.tar
+
+  # Push image to GitHub Packages.
+  push:
+    name: Push
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    needs:
+      - build
+
+    steps:
+      - name: Download stored images
+        uses: actions/download-artifact@v1
+        with:
+          name: paperdraft
+
+      - name: Load images
+        run: |
+          docker load --input paperdraft/image.tar
+
+      - name: Log into registry
+        run: |
+          echo "${{ secrets.DOCKER_HUB_TOKEN }}" |
+            docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
+
+      - name: Push core image
+        run: docker push $IMAGE_NAME

--- a/paperdraft.Dockerfile
+++ b/paperdraft.Dockerfile
@@ -1,4 +1,4 @@
-FROM pandoc/latex:2.10
+FROM pandoc/latex:2.11.2
 
 # Install additional LaTeX packages
 RUN tlmgr install \

--- a/paperdraft.Dockerfile
+++ b/paperdraft.Dockerfile
@@ -1,0 +1,24 @@
+FROM pandoc/latex:2.10
+
+# Install additional LaTeX packages
+RUN tlmgr install \
+  environ \
+  marginnote \
+  pgf \
+  preprint \
+  seqsplit \
+  tcolorbox \
+  titlesec \
+  trimspaces \
+  xstring
+
+# Copy templates, images, and other resources
+COPY ./resources /usr/local/share/openjournals
+
+ENV JOURNAL=joss
+
+# Invoce pandoc with special defaults file. Input is read from `paper.md`,
+# while output is written to `paper.pdf`
+ENTRYPOINT pandoc \
+  --defaults=/usr/local/share/openjournals/docker-defaults.yaml \
+  --defaults=/usr/local/share/openjournals/${JOURNAL}/defaults.yaml

--- a/paperdraft.Dockerfile
+++ b/paperdraft.Dockerfile
@@ -2,14 +2,29 @@ FROM pandoc/latex:2.10
 
 # Install additional LaTeX packages
 RUN tlmgr install \
+  algorithmicx \
+  algorithms \
+  booktabs \
+  caption \
+  collection-xetex \
   environ \
+  etoolbox \
+  fancyvrb \
+  float \
+  fontspec \
+  latexmk \
+  listings \
+  logreq \
   marginnote \
+  mathspec \
   pgf \
   preprint \
   seqsplit \
   tcolorbox \
   titlesec \
   trimspaces \
+  xcolor \
+  xkeyval \
   xstring
 
 # Create entrypoint script: invoke pandoc with special defaults files.

--- a/paperdraft.Dockerfile
+++ b/paperdraft.Dockerfile
@@ -27,18 +27,13 @@ RUN tlmgr install \
   xkeyval \
   xstring
 
-# Create entrypoint script: invoke pandoc with special defaults files.
-ARG openjournals_dir=/usr/local/share/openjournals
-RUN printf "#!/bin/sh\n/usr/bin/pandoc --defaults=%s --defaults=%s \"\$@\"\n" \
-           "$openjournals_dir/docker-defaults" \
-           "$openjournals_dir/\${JOURNAL}/defaults.yaml" \
-           > /usr/local/bin/paperdraft \
-  && chmod +x /usr/local/bin/paperdraft
-
 # Copy templates, images, and other resources
-COPY ./resources $openjournals_dir
+ARG openjournals_path=/usr/local/share/openjournals
+COPY ./resources $openjournals_path
+COPY ./resources/docker-entrypoint.sh /usr/local/bin/paperdraft
 
 ENV JOURNAL=joss
+ENV OPENJOURNALS_PATH=$openjournals_path
 
 # Input is read from `paper.md` by default, but can be overridden. Output is
 # written to `paper.pdf`

--- a/resources/docker-defaults.yaml
+++ b/resources/docker-defaults.yaml
@@ -27,8 +27,7 @@ metadata:
 resource-path: [".", '/usr/local/share/openjournals']
 
 filters:
-  - type: json
-    path: pandoc-citeproc
+  - citeproc
   - type: lua
     path: /usr/local/share/openjournals/time.lua
 

--- a/resources/docker-defaults.yaml
+++ b/resources/docker-defaults.yaml
@@ -1,7 +1,5 @@
 from: markdown
 to: latex
-input-files:
-  - paper.md
 output-file: paper.pdf
 standalone: true
 

--- a/resources/docker-defaults.yaml
+++ b/resources/docker-defaults.yaml
@@ -1,0 +1,45 @@
+from: markdown
+to: latex
+input-files:
+  - paper.md
+output-file: paper.pdf
+standalone: true
+
+# note that structured variables may be specified:
+variables:
+  archive_doi: 'DOI unavailable'
+  doi_batch_id: 'N/A'
+  editor_url: 'https://example.com'
+  formatted_doi: 'DOI unavailable'
+  repository: 'NO_REPOSITORY'
+  review_issue_url: 'N/A'
+  paper_url: 'NO PAPER URL'
+
+metadata:
+  citation_author: '¿citation_author?'
+  editor_name: 'Pending Editor'
+  issue: '¿ISSUE?'
+  page: '¿PAGE?'
+  published: 'N/A'
+  reviewers:
+    - 'Pending Reviewers'
+  submitted: 'N/A'
+  volume: '¿VOL?'
+
+resource-path: [".", '/usr/local/share/openjournals']
+
+filters:
+  - type: json
+    path: pandoc-citeproc
+  - type: lua
+    path: /usr/local/share/openjournals/time.lua
+
+# ERROR, WARNING, or INFO
+verbosity: INFO
+
+pdf-engine: xelatex
+dpi: 300
+
+default-image-extension: ".png"
+reference-links: true
+fail-if-warnings: true

--- a/resources/docker-entrypoint.sh
+++ b/resources/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# The first argument must always be the path to the main paper
+# file. The working directory is switched to the folder that the
+# paper file is in.
+input=$1
+shift
+
+input_file="$(basename $input)"
+cd "$(dirname $input)"
+
+/usr/local/bin/pandoc \
+    --defaults="$OPENJOURNALS_PATH"/docker-defaults.yaml \
+    --defaults="$OPENJOURNALS_PATH"/"$JOURNAL"/defaults.yaml \
+    "$input_file" \
+    "$@"

--- a/resources/jose/defaults.yaml
+++ b/resources/jose/defaults.yaml
@@ -1,0 +1,14 @@
+template: jose/latex.template
+csl: /usr/local/share/openjournals/jose/apa.csl
+
+variables:
+  joss_resource_url: 'N/A'
+  journal_abbrev_title: 'JOSE'
+  journal_alias: 'jose'
+  journal_issn: '2475-9066'
+  journal_name: 'Journal of Open Source Education'
+  journal_url: 'https://jose.theoj.org/'
+
+metadata:
+  aas_logo_path: '/usr/local/share/openjournals/jose/aas-logo.png'
+  logo_path: '/usr/local/share/openjournals/jose/logo.png'

--- a/resources/joss/defaults.yaml
+++ b/resources/joss/defaults.yaml
@@ -1,0 +1,14 @@
+template: joss/latex.template
+csl: /usr/local/share/openjournals/joss/apa.csl
+
+variables:
+  joss_resource_url: 'N/A'
+  journal_abbrev_title: 'JOSS'
+  journal_alias: 'joss'
+  journal_issn: '2475-9066'
+  journal_name: 'Journal of Open Source Software'
+  journal_url: 'https://joss.theoj.org/'
+
+metadata:
+  aas_logo_path: '/usr/local/share/openjournals/joss/aas-logo.png'
+  logo_path: '/usr/local/share/openjournals/joss/logo.png'

--- a/resources/time.lua
+++ b/resources/time.lua
@@ -1,0 +1,8 @@
+function Meta (meta)
+  local curtime = os.date('*t')
+  meta.timestamp = meta.timestamp or os.date('%Y%m%d%H%M%S')
+  meta.day = meta.day or tostring(curtime.day)
+  meta.month = meta.month or tostring(curtime.month)
+  meta.year = meta.year or tostring(curtime.year)
+  return meta
+end


### PR DESCRIPTION
Intended use:

    # Build the openjournals/paperdraft image.
    docker build \
           --tag=openjournals/paperdraft \
           --file paperdraft.Dockerfile .

    # Use image to compile a paper.md file into paper.pdf.
    docker run --rm \
           --volume $PWD/paper/folder:/data \
           --user $(id -u):$(id -g) \
           --env JOURNAL=joss \
           openjournals/paperdraft