### PR TITLE
add support for shortDOI

### DIFF
--- a/fixtures/paper/paper.bib
+++ b/fixtures/paper/paper.bib
@@ -15,7 +15,7 @@
   volume = {42},
   year = {2009},
   pages = {50-60},
-  doi = {10.1109/MC.2009.365},
+  doi = {10/fm2vqj},
   publisher = {IEEE Computer Society},
 }
 

--- a/lib/whedon/bibtex_parser.rb
+++ b/lib/whedon/bibtex_parser.rb
@@ -23,7 +23,7 @@ module Whedon
       entries.each do |entry|
         next if entry.comment?
         next if entry.preamble?
-        
+
         keys << "@#{entry.key}"
       end
 
@@ -72,6 +72,11 @@ module Whedon
       # Crossref DOIs need to be strings like 10.21105/joss.01461 rather
       # than https://doi.org/10.21105/joss.01461
       bare_doi = entry.doi.to_s[/\b(10[.][0-9]{4,}(?:[.][0-9]+)*\/(?:(?!["&\'<>])\S)+)\b/]
+
+      # Check for shortDOI formatted DOIs http://shortdoi.org
+      if bare_doi.nil?
+        bare_doi = entry.doi.to_s[/\b(10\/[a-bA-z0-9]+)\b/]
+      end
 
       # Sometimes there are weird characters in the DOI. This escapes
       escaped_doi = bare_doi.encode(:xml => :text)

--- a/spec/bibtex_spec.rb
+++ b/spec/bibtex_spec.rb
@@ -11,6 +11,12 @@ describe Whedon::BibtexParser do
     expect(citations_xml.search('citation[key="ref1"]').text.strip).to eql("10.1109/SERVICES.2007.63")
   end
 
+  it "should know how to generate shortDOI citations" do
+    citations_xml = Nokogiri::XML(subject.generate_citations)
+    expect(citations_xml.search('citation[key="ref2"]').children[1].name).to eql("doi")
+    expect(citations_xml.search('citation[key="ref2"]').text.strip).to eql("10/fm2vqj")
+  end
+
   it "should know how to generate non-DOI citations" do
     citations_xml = Nokogiri::XML(subject.generate_citations)
     expect(citations_xml.search('citation[key="ref6"]').children[1].name).to eql("unstructured_citation")


### PR DESCRIPTION
This PR allows .bib files to use [shortDOI](http://shortdoi.org) formatted DOIs

Closes #86