### PR TITLE
paperdraft image: allow to keep intermediary tex file

### DIFF
--- a/resources/docker-entrypoint.sh
+++ b/resources/docker-entrypoint.sh
@@ -1,13 +1,35 @@
 #!/bin/sh
+# Get options
+keep_tex="0"
+while getopts "k" "opt"; do
+    case "$opt" in
+        k)
+            keep_tex=1
+            ;;
+    esac
+done
+shift "$(expr $OPTIND - 1)"
+
 # The first argument must always be the path to the main paper
 # file. The working directory is switched to the folder that the
 # paper file is in.
-input=$1
+input="$1"
 shift
 
 input_file="$(basename $input)"
 cd "$(dirname $input)"
 
+## Create LaTeX file.
+if [ "$keep_tex" -ge 1 ]; then
+    /usr/local/bin/pandoc \
+        --defaults="$OPENJOURNALS_PATH"/docker-defaults.yaml \
+        --defaults="$OPENJOURNALS_PATH"/"$JOURNAL"/defaults.yaml \
+        --output=paper.tex \
+        "$input_file" \
+        "$@"
+fi
+
+## Create full PDF
 /usr/local/bin/pandoc \
     --defaults="$OPENJOURNALS_PATH"/docker-defaults.yaml \
     --defaults="$OPENJOURNALS_PATH"/"$JOURNAL"/defaults.yaml \


### PR DESCRIPTION
Passing the `-k` option when calling the image ensures that the
intermediary LaTeX file, named `paper.tex`, is put next to the
`paper.pdf` PDF file.

See openjournals/joss#132