### PR TITLE
Use Hack as monospace font with good unicode coverage

### DIFF
--- a/paperdraft.Dockerfile
+++ b/paperdraft.Dockerfile
@@ -1,5 +1,7 @@
 FROM pandoc/latex:2.11.2
 
+RUN apk add --no-cache ttf-hack
+
 # Update tlmgr
 RUN tlmgr update --self
 

--- a/resources/jose/latex.template
+++ b/resources/jose/latex.template
@@ -231,6 +231,9 @@ $endif$
 \UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts
 }{}
 
+% Use Hack https://sourcefoundry.org/hack/
+\setmonofont{Hack}
+
 \usepackage{hyperref}
 $if(colorlinks)$
 \PassOptionsToPackage{usenames,dvipsnames}{color} % color is loaded by hyperref

--- a/resources/joss/latex.template
+++ b/resources/joss/latex.template
@@ -239,6 +239,9 @@ $endif$
 \UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts
 }{}
 
+% Use Hack https://sourcefoundry.org/hack/
+\setmonofont{Hack}
+
 \usepackage{hyperref}
 $if(colorlinks)$
 \PassOptionsToPackage{usenames,dvipsnames}{color} % color is loaded by hyperref

--- a/resources/latex.template
+++ b/resources/latex.template
@@ -231,6 +231,9 @@ $endif$
 \UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts
 }{}
 
+% Use Hack https://sourcefoundry.org/hack/
+\setmonofont{Hack}
+
 \usepackage{hyperref}
 $if(colorlinks)$
 \PassOptionsToPackage{usenames,dvipsnames}{color} % color is loaded by hyperref


### PR DESCRIPTION
This allows unicode in code blocks, as is especially popular in Julia submissions (https://github.com/openjournals/joss/issues/963).

https://sourcefoundry.org/hack/