### PR TITLE
Fix number of params on CSLReferences

### DIFF
--- a/resources/joss/latex.template
+++ b/resources/joss/latex.template
@@ -80,7 +80,7 @@ $if(csl-refs)$
 \setlength{\cslhangindent}{1.5em}
 \newlength{\csllabelwidth}
 \setlength{\csllabelwidth}{3em}
-\newenvironment{CSLReferences}[3] % #1 hanging-ident, #2 entry spacing
+\newenvironment{CSLReferences}[2] % #1 hanging-ident, #2 entry spacing
  {% don't indent paragraphs
   \setlength{\parindent}{0pt}
   % turn on hanging indent if param 1 is 1


### PR DESCRIPTION
following https://github.com/jgm/pandoc/commit/356795dba06e2f1c4a0336c9836c132e97929926,
otherwise error occurs as in https://github.com/jgm/pandoc/issues/7215